### PR TITLE
docs: use "crayon-svelte" import as in example

### DIFF
--- a/docs/svelte.md
+++ b/docs/svelte.md
@@ -5,7 +5,7 @@ Simply load the svelte middleware, then pass Svelte components to the `mount` fu
 
 ```javascript
 import crayon from 'crayon'
-import svelte from 'crayon/svelte'
+import svelte from 'crayon-svelte'
 import Page from './Page.svelte'
 
 /*


### PR DESCRIPTION
at least this worked until  version 2.0.9 (for 2.1.x I am not quite sure)