### PR TITLE
readme svelte from 'crayon-svelte'

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -130,7 +130,7 @@ npm install --save crayon-svelte
 ```
 
 ```javascript
-import svelte from 'crayon-react'
+import svelte from 'crayon-svelte'
 app.use(svelte.router())
 ```
 <br>


### PR DESCRIPTION
The svelte example seems to have a mistake:
```js
import svelte from 'crayon-react'
```